### PR TITLE
Fix setting exclusive disks for blivet demo

### DIFF
--- a/demo-1-blivet
+++ b/demo-1-blivet
@@ -30,7 +30,7 @@ def get_vg_name():
 def get_blivet_obj(device_paths):
     """ Return a blivet.Blivet instance with disk filter appropriate for this demo. """
     blivet_obj = Blivet()
-    blivet_obj.config.exclusive_disks = [os.path.basename(d) for d in device_paths]
+    blivet_obj.exclusive_disks = [os.path.basename(d) for d in device_paths]
     blivet_obj.encryption_passphrase = LUKS_PASSPHRASE
     blivet_obj.reset()
     blivet_obj.devicetree.teardown_all()

--- a/demo-1-blivet
+++ b/demo-1-blivet
@@ -33,7 +33,6 @@ def get_blivet_obj(device_paths):
     blivet_obj.exclusive_disks = [os.path.basename(d) for d in device_paths]
     blivet_obj.encryption_passphrase = LUKS_PASSPHRASE
     blivet_obj.reset()
-    blivet_obj.devicetree.teardown_all()
     return blivet_obj
 
 


### PR DESCRIPTION
StorageDiscoveryConfig was removed in 3.0, the attributes were
moved to Blivet.